### PR TITLE
Add crypto as a category option

### DIFF
--- a/src/schemas/umbrel-app.yml.schema.ts
+++ b/src/schemas/umbrel-app.yml.schema.ts
@@ -44,6 +44,7 @@ export default async function umbrelAppYmlSchema() {
         "finance",
         "ai",
         "developer",
+        "crypto",
       ]),
       version: z.string().min(1),
       port: z.number().int().min(0).max(65535),


### PR DESCRIPTION
This adds the new `crypto` category option added in umbrelOS 1.5.